### PR TITLE
SFT-3998: Make it efficient.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "foundation-urtypes",
  "hex",
  "indoc",
+ "minicbor 0.24.2",
  "nu-ansi-term",
  "thiserror",
  "tokio",

--- a/abstracted/Cargo.toml
+++ b/abstracted/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "^1.0.58"
 tokio = { version = "1.37.0", features = ["full"]}
 hex = "^0.4.3"
 nu-ansi-term = "0.50.1"
+minicbor = "0.24"
 async-trait = "0.1.80"
 foundation-ur = { git = "https://github.com/Foundation-Devices/foundation-rs" }
 foundation-urtypes = { version = "0.5.0", git = "https://github.com/Foundation-Devices/foundation-rs" }


### PR DESCRIPTION
Before:

```
===== 💸 Envoy tells Passport the USD exchange rate. =====

Received 238 bytes over BLE
Looking like: ur:ql/1-8/lpadaycfaxatcyrtkkgerohdhstpsplftansfwlrhkaofwglotjnaxuovlclmotboxfdjsjlfhdihhktchcknsgofxhnkpfrlyahaautkbwdfxbghlsbdtpyueqzvawyeebgglvthnwplrkkkpbemtrflgfsjpjltdfpnnskasoyecetaojpvwinluglbkadcfoltpbdhhrketlazmurpktpaxemjzcwuopk
Received 238 bytes over BLE
Looking like: ur:ql/2-8/lpaoaycfaxatcyrtkkgerohdhsfsemdycyvteyesqdvlhdptuozctlmtrevometiehhspernpdsgdahpuofzhnidkpkkhtuyasnlnsonzchhpeotgltnkkyagacpmscmtlbzahldnsptgabtaelsldtyswflcypmlfntzcbdwmzcvabbneeysaoewmfsfmwnnbehrtvadatyiemtkifdpelyprjolbmeqzcp
Received 238 bytes over BLE
Looking like: ur:ql/3-8/lpaxaycfaxatcyrtkkgerohdhssfbyrnisrffnzopksndywyessfkpteurpefgjnueiabwswemaxlkpkbzchbetpiycthyrhbtlgutknvdleonasonhhdmialgrseoaohhsnvlkkgalofefhuygmytzmldtnlundskgrtbvoqzaeotdmgdronbhnroettiemcsfelffszsqzdpgmpkvyglbyswurpajoaagy
Received 238 bytes over BLE
Looking like: ur:ql/4-8/lpaaaycfaxatcyrtkkgerohdhszopsgwftmdlnmypfkpssinvtaxahfdjzmtcyieretbsslyhlwsiepfpmuehpuodwdilahpgmyamtammkfdcmzoredwsnndahjzbbcwhdmdaejlfhwfspkblnmslukpdltoimsngmasyatnmohleceelenbvsmshdlkbtyamokkmndkgooxfhjploltntlrcpclrsbzdmst
Received 238 bytes over BLE
Looking like: ur:ql/5-8/lpahaycfaxatcyrtkkgerohdhsgtptjtjomyktjkjerkonuynygdghkgfykefejsayfgjohfroweemgtndwevetnneptbtykaygujlgamdticwecdiyktylnbyrofdhltoaodwnsbgytgmmtetlfvteytnmtwlgaaabypdassfiyrlhsjtjtdmtydigrteceiartgrhdbyzmfrwkolcmhnaefyoekglbldkt
Received 238 bytes over BLE
Looking like: ur:ql/6-8/lpamaycfaxatcyrtkkgerohdhswmloioytldtdhylproberhfzvtlgemollgpsskgsdpzmdwesbbwpiemwzcayoeaygmgllfkeamdpvecmmuvwdiwerlmutlhkrtfdbscawebggwbajndprdaxonaaehtpftmwzsfsbemhaebdehwdzmnlntimzesgrksboxsgeorlcytnbavtbgiygshsdiaebevseceery
Received 238 bytes over BLE
Looking like: ur:ql/7-8/lpataycfaxatcyrtkkgerohdhscygtoydrrhcmgswsvetdtntpaopldihhfltptlgdnlbglglpbsfrbekofhfgylemmezsnttdhddatansfphdcxlefgtagufweyptrenldnjyeodasbmnolwtgreckpeoihlfnbjlghbtdegockdlhhoyahtpsotansgulftansfwlshddabwrtononmtfdlrtyhtwsswgy
Received 238 bytes over BLE
Looking like: ur:ql/8-8/lpayaycfaxatcyrtkkgerohdhschwpdmspclnelbzcwfqzspghfrsgvybwylmkbzgmpsfxjpuoecashfryjtgsbthldniebybygtdslesttsoygdtylulnhypysodnhydyaawfmehylebkkitansgrhdcxbskblelytbrneyotdegyzsaduotsnetbehctgmfrenkeemehrfvodrehfdmkflbsaejpluhscy
```

After:

```
===== 💸 Envoy tells Passport the USD exchange rate. =====

Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Sent 110 bytes over BLE
Received 110 bytes over BLE
Looking like: 8501081903071ac27ba8c45861d8c882d99c4284590242efae52a033997dd5b629fe5aedbd2fcba0f231fb475b839d08062d49708421bf8a0ca98db86756b0b4c982e2870a9d038b2f3aae297064c7b89e54c57f08189b7ba8ae8212f12fb59177b3fffc1d1a6c338bcf21fb2881
Received 110 bytes over BLE
Looking like: 8502081903071ac27ba8c4586184f0171907d46afe49e6222f5a479b70d83c898722746073c3be7538f0f87d36638af6e20c11032ae1eeec625ab1ee3fb99ee22e1d3fa147e86a10888b2c94a46b085f9e0099155e33a210691f7e451b7e348ca9761d62b83b29e09e1c87f4dc17
Received 110 bytes over BLE
Looking like: 8503081903071ac27ba8c4586136bd7a81711b5a02c125c7ba228a3f0838a35b0dd8911cd92d6594b0fa6baef3ad572154ef8fdca6ca7477adb0a1336a62e7d688223141de3a9e74db35b7255be02bec86690ea01557a6a47a40e63b1cae31bd746c00e4d5077660b6f9b416e55b
Received 110 bytes over BLE
Looking like: 8504081903071ac27ba8c458618a84fe9e09fd7f87207e544f166c3033a05089bba03419aa2755e6873818c99e79c454ca41a95d7b245d673ddad947722450740206849c098ee8bfd696c28e3a59a6c0828b3f448b3d0f4c1d8fd8006fbc10357060ab7fab483308843b7dc9bcd2
Received 110 bytes over BLE
Looking like: 8505081903071ac27ba8c45861d71d909d9c3a62ae379afef91a12518b79376b15a4aa9b1a775c37ef26606384c05d2b2fe815f83f47c76a9322469a39ec74256009e6b30ce3e29877d9d026530c9e0dfdfa4df28f03b9fc40536ce23b99e28ad9c1334bbfa5f1babaad04a3abac
Received 110 bytes over BLE
Looking like: 8506081903071ac27ba8c45861b903d3d899aefc2c7b03232bf23918199466870492a1f169b4a8c4b98d33a7ce5dcc2cbecce0b3f1e9bfeb000860ff97fbc1d18b2fe7ef7afc437fb2bd3bbddcf3463254fb6baabefcd9e35fe8aa0e473b53754257d0f458392311c5aa457d7b09
Received 110 bytes over BLE
Looking like: 8507081903071ac27ba8c45861bbd828dee05c4c6b4ed66e6d79ab09ef9a7e26506ae0026d237a7c8d064861b6c06b1a385825d99c415820dccf5257f053a6b8d51d0cd686e7c6f2db782fd5d9c4e0960f81a0cc32493d92a105d8c9d99c5382d99c42835825483ce32f6d1bf515
Received 110 bytes over BLE
Looking like: 8508081903071ac27ba8c45861538960948b484d9ec5d871f110ba0cbe60224d928f8d6ee61f1d1727434c2406b4fdae351b782f1e36f0504ebad131d30eaf1ff2a43ec6276b862bd99c4b5820f2233a8a93aa82b0cacf7f11eaf8cab4a2501af7aafbaecd1e1b312d4054332b00
🛂 Passport 📡 Received: SealedRequest(id: ce7109dc, body: «"exchangeRate"» [ ❰"currencyCode"❱: "USD", ❰"rate"❱: 65432.2109375 ], state: None, peer_continuation: Some)
🛂 Passport 💸 USD rate is: 65432.21
```

The `Part` is encoded on the UR encoder as bytewords but here we are doing it directly encoding to CBOR bytes and without a UR type.
