### PR TITLE
api: don't use unit struct (frb incompatibility)

### DIFF
--- a/api/src/api/backup.rs
+++ b/api/src/api/backup.rs
@@ -23,7 +23,7 @@ pub enum BackupShardResponse {
 }
 
 #[quantum_link]
-pub struct RestoreShardRequest;
+pub struct RestoreShardRequest {}
 
 #[quantum_link]
 pub enum RestoreShardResponse {


### PR DESCRIPTION
```
Skip parsing enum_or_struct `NamespacedName { namespace: Namespace { joined_path: "foundation_api::api::backup" }, name: "RestoreShardRequest" }` because of error (e=struct with unit fields are not supported yet, what about using `struct RestoreShardRequest {}` or `#[frb(opaque)] struct RestoreShardRequest;` instead)
```