### PR TITLE
Add PrimeFiatPreference message variant

### DIFF
--- a/api/src/api/fx.rs
+++ b/api/src/api/fx.rs
@@ -25,3 +25,10 @@ pub struct PricePoint {
     #[n(1)]
     pub timestamp: u64,
 }
+
+/// Prime → Envoy. ISO-4217 code; sent on settings change and on every reconnect.
+#[quantum_link]
+pub struct PrimeFiatPreference {
+    #[n(0)]
+    pub currency_code: String,
+}

--- a/api/src/api/message.rs
+++ b/api/src/api/message.rs
@@ -143,6 +143,7 @@ pub enum QuantumLinkMessage {
     #[n(39)]
     MagicBackupResponseV2(MagicBackupResponseV2),
 
+    // Skipped tags (e.g. #[n(32)]) are intentional and must not be reused.
     #[n(40)]
     PrimeFiatPreference(PrimeFiatPreference),
 }

--- a/api/src/api/message.rs
+++ b/api/src/api/message.rs
@@ -14,7 +14,7 @@ use crate::{
         FirmwareFetchEvent, FirmwareFetchRequest, FirmwareInstallEvent, FirmwareUpdateCheckRequest,
         FirmwareUpdateCheckResponse,
     },
-    fx::{ExchangeRate, ExchangeRateHistory},
+    fx::{ExchangeRate, ExchangeRateHistory, PrimeFiatPreference},
     pairing::{PairingRequest, PairingResponse, UnpairingRequest, UnpairingResponse},
     scv::SecurityCheck,
     status::{
@@ -142,4 +142,7 @@ pub enum QuantumLinkMessage {
     MagicBackupRequestV2(MagicBackupRequestV2),
     #[n(39)]
     MagicBackupResponseV2(MagicBackupResponseV2),
+
+    #[n(40)]
+    PrimeFiatPreference(PrimeFiatPreference),
 }


### PR DESCRIPTION
## Summary

Adds a new `PrimeFiatPreference` quantum-link message so Prime can tell Envoy which fiat the user has selected. Envoy will use that preference when sending `ExchangeRate`s back to Prime.

- New `PrimeFiatPreference { currency_code: String }` in `api/src/api/fx.rs`
- New `QuantumLinkMessage::PrimeFiatPreference` variant at tag `#[n(40)]`
- Comment near tail tags noting that skipped tags (e.g. `#[n(32)]`) are intentional and must not be reused

No behaviour change in this repo — purely the wire-format addition.

## Three-PR series — review/merge order

This is **PR 1/3** of an Option-B fix for non-USD fiat display on Prime. Other two PRs depend on this one being merged + tagged first (so they can pin to a stable tag rather than a fork rev).

1. **THIS PR** — `foundation-api`: add `PrimeFiatPreference` variant.
2. KeyOS: Foundation-Devices/KeyOS-dev#1734
3. Envoy: Foundation-Devices/envoy-dev#1263
