### PR TITLE
btp: decode chunk headers from unaligned buffers

### DIFF
--- a/btp/src/dechunk.rs
+++ b/btp/src/dechunk.rs
@@ -86,10 +86,7 @@ impl Chunk {
         let mut chunk = [0u8; CHUNK_DATA_SIZE];
         chunk[..data_len].copy_from_slice(&chunk_data[..data_len]);
 
-        Ok(Chunk {
-            header: *header,
-            chunk,
-        })
+        Ok(Chunk { header, chunk })
     }
 }
 

--- a/btp/src/lib.rs
+++ b/btp/src/lib.rs
@@ -39,8 +39,10 @@ impl Header {
         bytemuck::bytes_of(self)
     }
 
+    /// Reads a header out of `bytes`, which does not have to be aligned:
+    /// received packets are often a sub-slice of a larger transport buffer.
     #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<&Self> {
-        bytemuck::try_from_bytes::<Header>(bytes).ok()
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytemuck::try_pod_read_unaligned::<Header>(bytes).ok()
     }
 }

--- a/btp/src/tests.rs
+++ b/btp/src/tests.rs
@@ -256,6 +256,44 @@ fn chunk_decode_and_insert() {
     assert_eq!(dechunker.data(), Some(data.to_vec()));
 }
 
+/// Copies `chunk` into a buffer at an odd address and returns that sub-slice,
+/// mimicking a receive path that hands us a view into a larger packet buffer.
+fn unaligned<'a>(buf: &'a mut [u8], chunk: &[u8]) -> &'a [u8] {
+    let offset = if buf.as_ptr() as usize % 2 == 0 { 1 } else { 2 };
+    buf[offset..offset + chunk.len()].copy_from_slice(chunk);
+    let slice = &buf[offset..offset + chunk.len()];
+    assert_eq!(slice.as_ptr() as usize % 2, 1, "slice should be unaligned");
+    slice
+}
+
+#[test]
+fn decode_unaligned_chunk() {
+    let data = b"Chunk arriving on an odd address";
+    let chunks: Vec<_> = chunk(data).collect();
+
+    let mut buf = vec![0u8; APP_MTU + 2];
+    let slice = unaligned(&mut buf, &chunks[0]);
+
+    let decoded = Chunk::decode(slice).expect("decoding must not depend on buffer alignment");
+    assert_eq!(decoded.as_slice(), data);
+}
+
+#[test]
+fn receive_unaligned_chunks() {
+    let data = vec![7u8; CHUNK_DATA_SIZE * 2 + 1];
+    let chunks: Vec<_> = chunk(&data).collect();
+
+    let mut dechunker = Dechunker::new();
+    for chunk in &chunks {
+        let mut buf = vec![0u8; APP_MTU + 2];
+        dechunker
+            .receive(unaligned(&mut buf, chunk))
+            .expect("unaligned chunk should be received");
+    }
+
+    assert_eq!(dechunker.data(), Some(data));
+}
+
 #[test]
 fn chunk_decode_errors() {
     let small_data = vec![0u8; HEADER_SIZE - 1];


### PR DESCRIPTION
This PR proposes fixing `btp::Chunk::decode`, which rejects perfectly valid chunks when the caller hands it an unaligned buffer. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/326. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`Header::from_bytes` reads the 8-byte BTP header with `bytemuck::try_from_bytes`, which is a reference cast and therefore requires the input slice to satisfy `Header`'s 2-byte alignment. `Chunk::decode` passes `&data[..HEADER_SIZE]` straight through, so whether a chunk decodes depends on the *address* of the caller's buffer rather than on its contents. A receive path that hands the decoder a sub-slice of a larger packet buffer — say an application payload sitting at offset 3 of an `ATT_MTU` packet, `ATT_MTU` being `APP_MTU + 3` in the `consts` crate — lands on an odd address, and then every chunk it delivers is rejected with `DecodeError::InvalidHeader`. Nothing about those bytes is malformed, so the peer keeps sending, `Dechunker` never fills, and the transfer stalls with no useful error. The existing tests miss it because they always decode from the start of a fresh allocation, which is aligned.

Reproduced on `main` at a0615c6, by copying a chunk produced by `chunk()` into a buffer at an odd offset and decoding that sub-slice:

```
$ cargo test -p btp unaligned
running 2 tests
test tests::decode_unaligned_chunk ... FAILED
test tests::receive_unaligned_chunks ... FAILED

---- tests::decode_unaligned_chunk stdout ----
thread 'tests::decode_unaligned_chunk' panicked at btp/src/tests.rs:277:40:
decoding must not depend on buffer alignment: InvalidHeader

---- tests::receive_unaligned_chunks stdout ----
thread 'tests::receive_unaligned_chunks' panicked at btp/src/tests.rs:291:14:
unaligned chunk should be received: Decode(InvalidHeader)
```

## The change

`Header::from_bytes` now reads the header by value with `bytemuck::try_pod_read_unaligned` and returns `Option<Header>`; `Chunk::decode` drops the matching deref and moves the header into the `Chunk`. `Header` is `Pod` and `Copy` and was already being copied into the `Chunk`, so aligned input decodes byte-for-byte as it did before, and the size validation is unchanged — a slice that is not exactly `HEADER_SIZE` still yields `DecodeError::InvalidHeader`. `from_bytes` is private, so no public signature moves; the diff outside the tests is two lines.

Verification, all on the branch tree: the two regression tests above fail on `main` and pass with the change, covering both `Chunk::decode` directly and a full multi-chunk message reassembled through `Dechunker::receive` on odd-addressed slices. `cargo test --workspace --all-features` was run on a clean checkout before the change and again after — 112 tests passing before, 114 after (the two new ones), no test that passed before fails now. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are both clean, matching the checks in your Rust workflow. Nothing in `api`, `backup-shard` or `quantum-link-macros` is touched, so this should not conflict with the QLV2 work in flight.

## How this was managed

We tracked this work on a live board imported from this repository's own pull requests and labels — 78 stories, one per pull request, plus the label they carry — and the fix itself is this story:

- Story: https://eastagiletracker.com/projects/326/stories/210642
- Board: https://eastagiletracker.com/projects/326

![board](https://raw.githubusercontent.com/eastagiletracker/foundation-api/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
